### PR TITLE
update dependency to laravel 4.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "illuminate/support": "4.0.x",
+        "illuminate/support": "4.1.x",
         "php-instagram-api/php-instagram-api": "dev-master"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "illuminate/support": "4.1.x",
+        "illuminate/support": "4.x.x",
         "php-instagram-api/php-instagram-api": "dev-master"
     },
     "autoload": {


### PR DESCRIPTION
Needed to tweak this to upgrade to Laravel 4.1. Seems to work fine for my use case with the new release. Perhaps specifying the version and dependency for illuminate/support is unnecessary? 

Either way, thought I'd submit this just incase it's useful to someone. Would've made my life easier today.

Thanks for the package, it works very well.
